### PR TITLE
Fix author name

### DIFF
--- a/chricar_partner_id_number/__openerp__.py
+++ b/chricar_partner_id_number/__openerp__.py
@@ -47,7 +47,7 @@
     ],
     # Your information
     'author': 'ChriCar Beteiligungs- und Beratungs- GmbH, '
-              'Antiun Ingeniería, SL',
+              'Antiun Ingeniería S.L.',
     'maintainer': 'ChriCar Beteiligungs- und Beratungs- GmbH, '
                   'Antiun Ingeniería S.L.',
     'website': 'http://www.camptocamp.at, '


### PR DESCRIPTION
This is to fix fake statistics. In Antiun we noticed we had this module under a different author than the rest of modules in apps.odoo.com, because its name was not properly formatted. We would thank you a lot if you could please accept this change. Sorry for the disturbance.

cc @rafaelbn @antespi (original author).
